### PR TITLE
Use qemu backend with virt-builder

### DIFF
--- a/tasks/build_wrapper_image.yaml
+++ b/tasks/build_wrapper_image.yaml
@@ -6,6 +6,8 @@
 
 - name: Create wrapper image
   command: virt-builder {{ wrapper_base_image }} --selinux-relabel --run-command 'mkdir {{ wrapper_image_output_base_directory }}' --copy-in {{ output_directory }}:/var/lib/network-image-builder --run /tmp/virt-builder.script --output {{ wrapper_image_name }}
+  environment:
+    LIBGUESTFS_BACKEND: direct
 
 - name: Delete virt-builder script from /tmp
   file:


### PR DESCRIPTION
If not specified, default is libvirt which can be tricky to work with
when running the role on VMs.