### PR TITLE
rsync needed in base image for synchronize

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ enable_ssh_key_authentication: False
 wrap_images: False
 wrapper_image_name: ansible-network.img
 wrapper_base_image: fedora-27
-wrapper_image_packages: cloud-init qemu-system-x86.x86_64 git PyYAML python-paramiko python-jinja2 python-keyczar python-httplib2 python-setuptools python-six python2 python2-pip python3-pip python3-paramiko python3-jinja2 python3-httplib2 python3-setuptools python3-six telnet
+wrapper_image_packages: cloud-init qemu-system-x86.x86_64 git PyYAML python-paramiko python-jinja2 python-keyczar python-httplib2 python-setuptools python-six python2 python2-pip python3-pip python3-paramiko python3-jinja2 python3-httplib2 python3-setuptools python3-six telnet rsync
 wrapper_image_user: fedora
 wrapper_image_output_base_directory: /var/lib/network-image-builder
 


### PR DESCRIPTION
The synchronize Ansible module is used before any tests get called, so
ensure it's in the base image.