### PR TITLE
Add image_config_path parameter to role

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This role allows an operator to customize vendor networking images for use in CI
 
 The method taken here should work with any network platform.
 
-## Sample playbook
+## Sample playbook with templatized configuration
 
 `build-images.yaml`
 
@@ -19,6 +19,8 @@ The method taken here should work with any network platform.
       vars:
         src_image_path: "{{ image.src_image_path }}"
         image_name: "{{ image.image_name }}"
+        admin_user_password: myadminpass
+        regular_user_password: myregularpass
       loop_control:
         loop_var: image
       with_items:
@@ -26,6 +28,29 @@ The method taken here should work with any network platform.
           image_name: nxos
         - src_image_path: /home/ricky/images/vEOS-lab-4.20.1F-combined.vmdk
           image_name: eos
+```
+
+## Sample playbook with arbitrary configuration
+
+`build-images.yaml`
+
+```yaml
+- hosts: localhost
+  connection: local
+  gather_facts: no
+
+  tasks:
+    - include_role:
+        name: network-image-builder
+      vars:
+        src_image_path: "{{ image.src_image_path }}"
+        image_name: "{{ image.image_name }}"
+        image_config_path: /my/path/to/my/image/config
+      loop_control:
+        loop_var: image
+      with_items:
+        - src_image_path: /home/ricky/images/nxosv-final.7.0.3.I7.3.qcow2
+          image_name: nxos
 ```
 
 ```sh

--- a/tasks/csr/16.03.05/configure.yaml
+++ b/tasks/csr/16.03.05/configure.yaml
@@ -1,6 +1,6 @@
 ---
 - ios_config:
-    src: "{{ platform }}/{{ build_version }}/config.j2"
+    src: "{{ image_config_path | default (platform + '/' + build_version + '/config.j2') }}"
     save: yes
   vars:
     ansible_user: admin

--- a/tasks/eos/4.20.1F/configure.yaml
+++ b/tasks/eos/4.20.1F/configure.yaml
@@ -1,6 +1,6 @@
 ---
 - eos_config:
-    src: "{{ platform }}/{{ build_version }}/config.j2"
+    src: "{{ image_config_path | default (platform + '/' + build_version + '/config.j2') }}"
     save_when: always
     authorize: yes
   vars:

--- a/tasks/nxos/7.0.3.I7.3/configure.yaml
+++ b/tasks/nxos/7.0.3.I7.3/configure.yaml
@@ -1,6 +1,6 @@
 ---
 - nxos_config:
-    src: "{{ platform }}/{{ build_version }}/config.j2"
+    src: "{{ image_config_path | default (platform + '/' + build_version + '/config.j2') }}"
     save_when: always
   vars:
     ansible_user: admin

--- a/tasks/vmx/17.4R1/configure.yaml
+++ b/tasks/vmx/17.4R1/configure.yaml
@@ -1,6 +1,6 @@
 ---
 - junos_config:
-    src: "{{ platform }}/{{ build_version }}/config.j2"
+    src: "{{ image_config_path | default (platform + '/' + build_version + '/config.j2') }}"
   vars:
     ansible_user: root
     ansible_ssh_pass: root123

--- a/tasks/vqfx/17.4R1/configure.yaml
+++ b/tasks/vqfx/17.4R1/configure.yaml
@@ -1,6 +1,6 @@
 ---
 - junos_config:
-    src: "{{ platform }}/{{ build_version }}/config.j2"
+    src: "{{ image_config_path | default (platform + '/' + build_version + '/config.j2') }}"
   vars:
     ansible_user: root
     ansible_ssh_pass: root123

--- a/tasks/vsrx/18.1R1/configure.yaml
+++ b/tasks/vsrx/18.1R1/configure.yaml
@@ -1,6 +1,6 @@
 ---
 - junos_config:
-    src: "{{ platform }}/{{ build_version }}/config.j2"
+    src: "{{ image_config_path | default (platform + '/' + build_version + '/config.j2') }}"
   vars:
     ansible_user: root
     ansible_ssh_pass: root123

--- a/tasks/vyos/1.1.8/configure.yaml
+++ b/tasks/vyos/1.1.8/configure.yaml
@@ -1,6 +1,6 @@
 ---
 - vyos_config:
-    src: "{{ platform }}/{{ build_version }}/config.j2"
+    src: "{{ image_config_path | default (platform + '/' + build_version + '/config.j2') }}"
     save: yes
   vars:
     ansible_user: vyos


### PR DESCRIPTION
If defined, the config step for the image will push the config contained
in image_config_path file, instead of using image template.